### PR TITLE
Move jquery pin off the beta to 4.0.0 stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dompurify": "^3.2.4",
         "gmail-js": "^1.1.16",
         "jose": "^6.1.3",
-        "jquery": "^4.0.0-beta",
+        "jquery": "^4.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-hot-loader": "^4.13.1",
@@ -8846,9 +8846,10 @@
       }
     },
     "node_modules/jquery": {
-      "version": "4.0.0-beta",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0-beta.tgz",
-      "integrity": "sha512-F/LxAJ1KuoIfS5j6T5R57YceLJfXjwBl5hJ9za2itWyCy24YqU5R/DzRf76RrpeHfpJgQyqwnPbUQbjSfoEBcQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -19266,9 +19267,9 @@
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="
     },
     "jquery": {
-      "version": "4.0.0-beta",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0-beta.tgz",
-      "integrity": "sha512-F/LxAJ1KuoIfS5j6T5R57YceLJfXjwBl5hJ9za2itWyCy24YqU5R/DzRf76RrpeHfpJgQyqwnPbUQbjSfoEBcQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dompurify": "^3.2.4",
     "gmail-js": "^1.1.16",
     "jose": "^6.1.3",
-    "jquery": "^4.0.0-beta",
+    "jquery": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hot-loader": "^4.13.1",


### PR DESCRIPTION
## Summary

PR #508 bumped jquery to `^4.0.0-beta` in March 2024 when 4.x was still pre-release. jQuery 4.0.0 stable shipped on npm in January 2026. The `^4.0.0-beta` caret already resolved to 4.0.0 stable on a fresh install, but `package-lock.json` was pinned to the beta release.

Bumps the `package.json` pin to `^4.0.0` and refreshes the lockfile.

## Test plan

- [x] `npm install` resolves to `jquery@4.0.0` (verified in lockfile)
- [x] Webpack build succeeds with the new pin
- [x] `npm run lint` clean (two pre-existing warnings unrelated to this change)

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_