### PR TITLE
Validate sender on background message listeners

### DIFF
--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -15,14 +15,43 @@ if (sentryEnabled) {
 console.log('This is the background page.');
 console.log('Put the background scripts here.');
 
+// Validate that an inbound externally_connectable message actually originated
+// from a mail.google.com page. The manifest's `externally_connectable.matches`
+// is the primary gate, but explicit validation is cheap defense-in-depth and
+// surfaces an obvious red flag if the manifest ever loosens.
+//
+// Note: this does NOT prevent token theft from a malicious script *already
+// running* in a Gmail tab (e.g., from another extension that injects into
+// Gmail, or a Gmail XSS). The proper fix is to stop exposing raw tokens to
+// page-context callers at all and instead proxy API calls through the
+// background worker; that's a larger refactor tracked separately.
+function isAllowedExternalSender(
+  sender: chrome.runtime.MessageSender
+): boolean {
+  if (typeof sender.url !== 'string') return false;
+  let url: URL;
+  try {
+    url = new URL(sender.url);
+  } catch {
+    return false;
+  }
+  return url.protocol === 'https:' && url.hostname === 'mail.google.com';
+}
+
 chrome.runtime.onMessageExternal.addListener(
   function (message, sender, send_response) {
-    // TODO: check the sender here
-    console.log('background::onMessageExternal', sender, message);
+    if (!isAllowedExternalSender(sender)) {
+      console.warn('background::onMessageExternal rejected sender', sender.url);
+      send_response();
+      return false;
+    }
+
     const runner = async () => {
       if (message.your === 'STORAGE') {
         const { emailAccount } = message;
-        console.log('receive storage', emailAccount);
+        if (typeof emailAccount !== 'string') {
+          return;
+        }
         let storageData;
         try {
           storageData = await chrome.storage.sync.get();
@@ -36,9 +65,7 @@ chrome.runtime.onMessageExternal.addListener(
         } else {
           return;
         }
-      } /*else if (message.your === 'TEST') {
-      setTimeout(() => send_response({ foo: 'bar' }), 10);
-    }*/
+      }
       return;
     };
     runner().then((response) => send_response(response));
@@ -46,11 +73,17 @@ chrome.runtime.onMessageExternal.addListener(
   }
 );
 
+// chrome.runtime.onMessage only fires for messages from THIS extension's own
+// contexts (content scripts, popup, options pages). Chrome guarantees
+// sender.id === chrome.runtime.id, so we don't need an explicit id check, but
+// we do reject anything that isn't from our own scripts.
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  // TODO: check the sender here
-  console.log('background::onMessage', request, sender);
+  if (sender.id !== chrome.runtime.id) {
+    console.warn('background::onMessage rejected sender', sender);
+    sendResponse();
+    return false;
+  }
   if (request.your === 'LOGIN_IN') {
-    console.log('receive login');
     notifyLogin(request.emailAccount);
 
     // Close the tab automatically
@@ -59,7 +92,6 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       chrome.tabs.remove([tabId]);
     }
   } else if (request.your === 'LOG_OUT') {
-    console.log('receive logout');
     notifyLogout();
   }
   // https://stackoverflow.com/a/71520415/2638485


### PR DESCRIPTION
## Summary

Both message listeners in `src/pages/Background/index.ts` had literal `// TODO: check the sender here` comments and accepted any payload.

- **`onMessageExternal`**: now requires `sender.url` to be `https://mail.google.com/*` (parsed via `URL`, checked on `protocol === 'https:'` and `hostname === 'mail.google.com'`). The manifest's `externally_connectable.matches` is still the primary gate; the explicit check is cheap defense-in-depth and fails loudly if the manifest ever loosens.
- **`onMessage`**: now checks `sender.id === chrome.runtime.id` before acting on `LOGIN_IN` / `LOG_OUT` messages. Chrome guarantees this in practice but an explicit check makes the contract obvious.
- The `STORAGE` handler also now type-checks `emailAccount` as a string instead of blindly indexing storage by whatever was passed.

## What this does NOT fix

A malicious script *already running* in a Gmail tab (a malicious extension that injects into Gmail, a Gmail XSS, "paste this in console" social engineering) can still `sendMessage` to this extension's id and walk away with a token. The proper fix is to stop exposing raw tokens to page-context callers at all and proxy API calls through the background worker. That's a larger refactor; flagged as a TODO in the source comment so it isn't forgotten.

## Test plan

- [x] Production webpack build succeeds.
- [x] `npm run lint` clean (two pre-existing warnings unrelated to this change).
- [x] Behavior unchanged for legitimate callers (`gmailJsLoader.ts` calls `chrome.runtime.sendMessage(extensionId, { your: 'STORAGE', emailAccount })` from a mail.google.com page; `sender.url` matches).

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_