### PR TITLE
Add 15s timeout to all extension fetch calls

### DIFF
--- a/src/gmailJsLoader.ts
+++ b/src/gmailJsLoader.ts
@@ -15,6 +15,7 @@ import ThreadTrackingButton from './containers/ThreadTrackingButton';
 import useStore from './containers/store';
 import { View } from './types';
 import Sentry from './sentry';
+import { fetchWithTimeout } from './utils/fetchWithTimeout';
 
 // import style required for TS to work
 const GmailFactory = require('gmail-js');
@@ -99,7 +100,7 @@ async function fetchAuth(
     throw new Error('Not logged in');
   }
 
-  return await fetch(input, {
+  return await fetchWithTimeout(input, {
     ...(init ?? {}),
     headers: { ...(init?.headers ?? {}), Authorization: authorization },
   });
@@ -357,7 +358,7 @@ function setupTracking() {
 const requestLogin = async () => {
   const emailAccount = useStore.getState().userEmail;
 
-  await fetch(loginUrl, {
+  await fetchWithTimeout(loginUrl, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,4 +1,5 @@
 import './sentry';
+import { fetchWithTimeout } from './utils/fetchWithTimeout';
 
 // -------------------------------------------------
 
@@ -68,7 +69,7 @@ async function processQsLogin() {
     console.log('Missing token');
     return;
   }
-  const resp = await fetch(useMagicUrl, {
+  const resp = await fetchWithTimeout(useMagicUrl, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -1,0 +1,36 @@
+// Default fetch has no timeout — a backend that hangs leaves the extension
+// hung indefinitely. This wrapper aborts via AbortController after a fixed
+// window so callers see a clean rejection instead of waiting forever.
+
+export const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
+export async function fetchWithTimeout(
+  input: RequestInfo,
+  init?: RequestInit & { timeoutMs?: number }
+): Promise<Response> {
+  const { timeoutMs = DEFAULT_FETCH_TIMEOUT_MS, signal, ...rest } = init ?? {};
+
+  const controller = new AbortController();
+  // If the caller passed their own signal, chain it: abort us when theirs
+  // aborts, so a higher-level cancel still propagates.
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+    } else {
+      signal.addEventListener('abort', () => controller.abort(signal.reason), {
+        once: true,
+      });
+    }
+  }
+
+  const timer = setTimeout(
+    () => controller.abort(new DOMException('Timeout', 'TimeoutError')),
+    timeoutMs
+  );
+
+  try {
+    return await fetch(input, { ...rest, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

`fetch` has no default timeout. If the backend hangs (slow geo lookup, overloaded dyno, network blip) extension calls hang forever and tracking buttons silently stop responding with no signal to the user.

Adds `src/utils/fetchWithTimeout.ts`: a thin AbortController-based wrapper that aborts after a configurable window (default 15s). A caller-supplied `AbortSignal` is chained so higher-level cancellations still propagate.

Swaps every direct `fetch()` for the wrapper:

- `gmailJsLoader.ts:fetchAuth` (covers `/api/v1/views/`, `/api/v1/trackers/`, `/api/v1/threads/.../views/`)
- `gmailJsLoader.ts:requestLogin` (`/api/v1/login/request-magic`)
- `login.ts:processQsLogin` (`/api/v1/login/use-magic`)

## Test plan

- [x] Production webpack build succeeds.
- [x] `npm run lint` clean (two pre-existing warnings unrelated).
- [x] Behavior unchanged on the happy path (timeout never fires on a normal-latency response).

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_