### PR TITLE
Bound the popout_thread poll loop

### DIFF
--- a/src/gmailJsLoader.ts
+++ b/src/gmailJsLoader.ts
@@ -119,24 +119,36 @@ const popoutThreadConfig = {
 
 gmail.observe.register(POPOUT_THREAD_EVENT, popoutThreadConfig);
 
+// Poll for the thread element with a hard cap so we don't keep checking
+// indefinitely if the DOM never produces it (e.g., Gmail's UI changed, or
+// the popout was closed before our interval found the element).
+const POPOUT_POLL_INTERVAL_MS = 100;
+const POPOUT_POLL_MAX_ATTEMPTS = 100; // 10s total
 gmail.observe.on_dom(POPOUT_THREAD_EVENT, function (obj: JQuery<HTMLElement>) {
+  let attempts = 0;
   const handle = setInterval(() => {
+    attempts += 1;
     const threadElem = obj[0].querySelector<HTMLElement>(
       '[data-thread-perm-id]'
     );
     if (threadElem) {
       clearInterval(handle);
-
       const threadId: string | undefined = threadElem.dataset['threadPermId'];
       if (threadId) {
-        console.log('popout_thread. threadId:', threadId);
         useStore.setState({ isPopout: true });
         setupInThread(threadId);
       } else {
         console.log('popout_thread no threadId', threadElem);
       }
+    } else if (attempts >= POPOUT_POLL_MAX_ATTEMPTS) {
+      clearInterval(handle);
+      console.warn(
+        'popout_thread gave up after',
+        POPOUT_POLL_MAX_ATTEMPTS,
+        'attempts'
+      );
     }
-  }, 100);
+  }, POPOUT_POLL_INTERVAL_MS);
 });
 
 const closeModal = () => {


### PR DESCRIPTION
## Summary

The `setInterval` in the `popout_thread` handler polls every 100ms for `[data-thread-perm-id]` and `clearInterval`s when it finds it. If the element never appears (Gmail UI change, popout closed before the interval found the element, etc.) it polls forever.

Caps at 100 attempts (10s total) then `clearInterval` and logs a warning. Happy path unchanged.

## What this does NOT change

The other `setInterval` in this file (`setupTracking + setupLogin` every 500ms) is intentional polling for Gmail re-renders. Both callees are idempotent (`if (buttons.length === 0)` guard before doing any work) so per-tick cost is bounded. Leaving alone; a MutationObserver-based rewrite could be a follow-up but isn't required.

## Test plan

- [x] Production webpack build succeeds.
- [x] `npm run lint` clean (two pre-existing warnings unrelated to this change).

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_