### PR TITLE
Surface backend fetch failures to the user

### DIFF
--- a/src/containers/LoginButton.tsx
+++ b/src/containers/LoginButton.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import useStore from './store';
 
-type LoginState = 'UNREQUESTED' | 'REQUESTING' | 'REQUESTED';
+type LoginState = 'UNREQUESTED' | 'REQUESTING' | 'REQUESTED' | 'FAILED';
+
+const FAILED_RESET_MS = 5_000;
 
 export default function LoginButton({
   requestLogin,
@@ -9,6 +11,7 @@ export default function LoginButton({
   requestLogin: () => Promise<void>;
 }): React.ReactElement {
   const [loginState, setLoginState] = useState<LoginState>('UNREQUESTED');
+  const [errorTitle, setErrorTitle] = useState<string | undefined>(undefined);
   const isLoggedIn = useStore((state) => state.isLoggedIn());
 
   let label: string;
@@ -16,23 +19,40 @@ export default function LoginButton({
     label = 'Requesting...';
   } else if (loginState === 'REQUESTED') {
     label = 'Requested';
+  } else if (loginState === 'FAILED') {
+    label = 'Login failed — try again';
   } else {
     label = 'Login';
   }
 
   const doLogin = async () => {
-    if (loginState !== 'UNREQUESTED') {
+    if (loginState === 'REQUESTING' || loginState === 'REQUESTED') {
       return;
     }
     setLoginState('REQUESTING');
-    await requestLogin();
-    // handle requestLogin failing
-    setLoginState('REQUESTED');
+    setErrorTitle(undefined);
+    try {
+      await requestLogin();
+      setLoginState('REQUESTED');
+    } catch (err) {
+      // requestLogin throws on network/timeout/rate-limit; surface this to
+      // the user instead of leaving the button stuck on "Requested".
+      console.error('LoginButton: requestLogin failed', err);
+      setErrorTitle(err instanceof Error ? err.message : String(err));
+      setLoginState('FAILED');
+      // After a few seconds, reset so the user can retry.
+      setTimeout(() => {
+        setLoginState((current) =>
+          current === 'FAILED' ? 'UNREQUESTED' : current
+        );
+      }, FAILED_RESET_MS);
+    }
   };
 
   useEffect(() => {
     if (isLoggedIn) {
       setLoginState('UNREQUESTED');
+      setErrorTitle(undefined);
     }
   }, [isLoggedIn]);
 
@@ -42,7 +62,7 @@ export default function LoginButton({
 
   // we should pass a sync function to onClick
   return (
-    <div style={style} onClick={doLogin}>
+    <div style={style} onClick={doLogin} title={errorTitle}>
       {label}
     </div>
   );

--- a/src/containers/TrackingButton.tsx
+++ b/src/containers/TrackingButton.tsx
@@ -50,14 +50,20 @@ export default function TrackingButton({
       : { marginLeft: '12px', marginRight: '12px' };
 
   let message = 'Tracking';
+  let title: string | undefined;
   if (views != null && views.length > 0) {
     message = `${message} (${dayjs().to(dayjs(views[0].createdAt), false)})`;
   } else if (views === null) {
-    message = `${message} (err)`;
+    // getUserViews swallows fetch errors and returns null; surface a clearer
+    // hint to the user. The exact reason (timeout, 5xx, rate limit) is in
+    // the console and Sentry.
+    message = 'Tracking unavailable';
+    title =
+      'Could not reach the tracking backend. Check your connection and try again in a moment.';
   }
 
   return (
-    <div style={style} onClick={onClick}>
+    <div style={style} onClick={onClick} title={title}>
       {message}
     </div>
   );

--- a/src/gmailJsLoader.ts
+++ b/src/gmailJsLoader.ts
@@ -166,8 +166,10 @@ const getThreadViews = async (threadId: string): Promise<View[] | null> => {
       const responseData = await resp.json();
       return responseData.data ?? null;
     }
+    console.warn('getThreadViews: non-OK response', resp.status);
   } catch (e) {
-    console.log(e);
+    console.error('getThreadViews failed', e);
+    Sentry.captureException(e);
   }
   return null;
 };
@@ -307,8 +309,17 @@ async function getUserViews(): Promise<View[] | null> {
   try {
     resp = await fetchAuth(url);
   } catch (error) {
-    // TODO(cancan101): we could try to verify the type of error here
-    // and then selectively log / report to Sentry/
+    // AbortError (our own timeout) and TypeError (network) are the common
+    // benign cases; everything else gets a Sentry capture so we can spot
+    // backend regressions.
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      console.warn('getUserViews timed out');
+    } else if (error instanceof TypeError) {
+      console.warn('getUserViews network error', error);
+    } else {
+      console.error('getUserViews failed', error);
+      Sentry.captureException(error);
+    }
     return null;
   }
   if (resp.ok) {
@@ -317,6 +328,8 @@ async function getUserViews(): Promise<View[] | null> {
       const allViews = respData.data as View[];
       return allViews.slice(0, INBOX_VIEW_LIST_MAX_SHOWN);
     }
+  } else {
+    console.warn('getUserViews: non-OK response', resp.status);
   }
   return null;
 }
@@ -505,7 +518,10 @@ gmail.observe.on('load', () => {
           body: JSON.stringify(reportData),
         });
       } catch (e) {
-        console.log(e);
+        // Tracker report failed; user already sent the email, so we can't
+        // do anything to recover, but we should at least know about it.
+        console.error('tracker report failed', e);
+        Sentry.captureException(e);
       }
     } else {
       console.log('No trackers found in email');


### PR DESCRIPTION
## Summary

Several fetch-failure paths were silently swallowed. When the backend rate-limited or went down, the user saw either a stuck button or a cryptic `(err)` tag with no explanation.

- **`LoginButton`**: `requestLogin()` rejection (timeout, rate-limit, network) left the button stuck on `"Requested"` forever — there was a literal `// handle requestLogin failing` TODO. Added a `FAILED` state with `"Login failed — try again"`, a tooltip carrying the underlying error message, and an auto-reset after 5s so the user can retry without reloading the tab.
- **`TrackingButton`**: cryptic `"(err)"` tag is now `"Tracking unavailable"` with a tooltip explaining the situation.
- **`gmailJsLoader` `getThreadViews` / `getUserViews` / tracker report**: failures were `console.log`'d with no Sentry capture, so they weren't observable in production. Categorize errors (TimeoutError, network `TypeError`, other) and Sentry-capture the unexpected ones. Timeouts and network errors are `console.warn`'d but not Sentry-reported (high signal-to-noise on real outages).

## Test plan

- [x] Production webpack build succeeds.
- [x] `npm run lint` clean (two pre-existing warnings unrelated).
- [x] Manual sanity: the LoginButton's `FAILED` → `UNREQUESTED` auto-reset uses a functional setState so it won't clobber a real state change that happened in the meantime.

https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpoWS1x83HWLR6iFccj2K)_